### PR TITLE
Specify DatabaseTasks.migrations_paths when execute pdns:* tasks

### DIFF
--- a/lib/pdns.rb
+++ b/lib/pdns.rb
@@ -17,6 +17,9 @@ module PDNS
   mattr_accessor :db_dir_path
   self.db_dir_path = File.expand_path('../../db', __FILE__)
 
+  mattr_accessor :migrations_path
+  self.migrations_path = File.expand_path('../../db/migrate', __FILE__)
+
   mattr_accessor :domain_as_json
   self.domain_as_json = nil
 

--- a/lib/tasks/pdns_tasks.rake
+++ b/lib/tasks/pdns_tasks.rake
@@ -5,6 +5,7 @@ namespace :pdns do
   task prepare: %i(environment) do
     DatabaseTasks.database_configuration = PDNS.db_conf
     DatabaseTasks.db_dir = PDNS.db_dir_path
+    DatabaseTasks.migrations_paths = PDNS.migrations_path
     ActiveRecord::Base.configurations = DatabaseTasks.database_configuration
     DatabaseTasks.current_config = DatabaseTasks.database_configuration[Rails.env]
   end


### PR DESCRIPTION
If you run `pdns:migrate` from Rails app root, the value of `DatabaseTasks.migrations_paths` becomes `app/db/migrate`.
Then, the app migration is executed in the database of pdns.

So, I specified DatabaseTasks.migrations_paths when execute pdns:* tasks.